### PR TITLE
Fix bot start in AWS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "description": "",
   "scripts": {
-    "start": "DEBUG=ERROR-*,WARN-*,INFO-* node build/bot",
+    "start": "DEBUG=ERROR-*,WARN-*,INFO-* node build/src/bot",
     "dev": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-*,-DEBUG-helper*,-DEBUG-util* nodemon -r dotenv/config  -r tsconfig-paths/register src/bot.ts",
     "dev:debug": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-* nodemon src/bot.ts -r dotenv/config src/bot.ts -r tsconfig-paths/register",
     "dev:info": "DEBUG=ERROR-*,WARN-*,INFO-* nodemon src/bot.ts -r dotenv/config src/bot.ts -r tsconfig-paths/register",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.2",
   "description": "",
   "scripts": {
-    "start": "DEBUG=ERROR-*,WARN-*,INFO-* node build/src/bot",
+    "start": "DEBUG=ERROR-*,WARN-*,INFO-* NODE_PATH=build/src node build/src/bot",
+    "start:env": "DEBUG=ERROR-*,WARN-*,INFO-* NODE_PATH=build/src node -r dotenv/config build/src/bot",
     "dev": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-*,-DEBUG-helper*,-DEBUG-util* nodemon -r dotenv/config  -r tsconfig-paths/register src/bot.ts",
     "dev:debug": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-* nodemon src/bot.ts -r dotenv/config src/bot.ts -r tsconfig-paths/register",
     "dev:info": "DEBUG=ERROR-*,WARN-*,INFO-* nodemon src/bot.ts -r dotenv/config src/bot.ts -r tsconfig-paths/register",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,12 @@
     "baseUrl": "./src/",
     "outDir": "./build"
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "node_modules/web3-*/types/*.d.ts", "node_modules/moment/moment.d.ts"],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "node_modules/web3-*/types/*.d.ts",
+    "node_modules/moment/moment.d.ts",
+    "src/**/*.json"
+  ],
   "exclude": ["node_modules", "coverage", "build"]
 }


### PR DESCRIPTION
Several issues where affecting the bots not to run in AWS:
- The JSON files where not being copied, now TS do that
-  Not finding the start script. It changed from `build/bot` to `build/src/bot`
- The absolute paths resolution were not working, cause the root needs to be `build/src/bot` so  now using `NODE_PATH` to instruct it

Then we will just need to add the env vars in AWS and it should be fine!

Additionally, I created `start:env` script to make it easier to run the transpiled JS locally without providing all the env vars.