### PR TITLE
Add dex js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "@gnosis.pm/dex-js": "^0.0.7",
     "@gnosis.pm/dex-react": "^0.0.4",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",

--- a/test/sandbox/dex-js/sayHi.ts
+++ b/test/sandbox/dex-js/sayHi.ts
@@ -1,0 +1,16 @@
+import { sayHi, DfusionContract } from '@gnosis.pm/dex-js'
+import Logger from 'helpers/Logger'
+
+/**
+ *  SANDBOX: Watch the placement of orders
+ *  RUN:     yarn sandbox test/sandbox/dex-js/sayHi.ts
+ */
+
+const log = new Logger('sandbox:dex-js:sayHi')
+
+async function exec (): Promise<void> {
+  log.info('sayHi. DfusionContract: ', DfusionContract)
+  sayHi()
+}
+
+exec().catch(log.errorHandler)

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,6 +448,13 @@
   dependencies:
     web3connect "^1.0.0-beta.23"
 
+"@gnosis.pm/dex-js@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.0.7.tgz#634dfd6541a29ca81788f2215a848a419f15d714"
+  integrity sha512-42EXjtaFGAR2jm0SOrE8EI2tqqiLjV4zf1h6+M3aojsBIv/Z1kKevQPA+qVbBJIod29bROGXWuLv7N09Vel/5A==
+  dependencies:
+    web3 "^1.2.4"
+
 "@gnosis.pm/dex-react@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-react/-/dex-react-0.0.4.tgz#0bcaf14274250d8dbd32c95021ba43bb23c6b8dd"


### PR DESCRIPTION
* Adds dependency to `dex-js`
* Makes sure we can use the lib and the typescrypt definitions work
* Adds a sandbox to easily test the exposed `satHi` function and `DfusionContract`, with the following result:

![image](https://user-images.githubusercontent.com/2352112/70058095-941be300-15de-11ea-9e37-9ff20480749d.png)
