### PR TITLE
Handle unknown tokens

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -187,9 +187,7 @@ dfusionService.watchOrderPlacement({
     message += `\n  - *Expires*: \`${moment(validUntil).calendar()} GMT\`, \`${moment(validUntil).fromNow()}\``
     if (!sellToken.known || !buyToken.known) {
       message +=
-        '\n  - "Maybe <token-symbol>" means the token is not recognizable as a token in the following [web](' +
-        WEB_BASE_URL +
-        ')'
+        '\n  - "Maybe" means one or more tokens claim to be called as shown, but it\'s not currently part of the list of [known tokens](https://github.com/gnosis/dex-react/blob/master/src/api/tokenList/tokenList.json). Make sure you verify the address yourself before trading against it.'
     }
     message += `\n\nFill the order here: ${WEB_BASE_URL}/trade/${sellTokenParam}-${buyTokenParam}?sell=${fillSellAmountFmt}&buy=${buyAmountFullFmt}`
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -165,15 +165,6 @@ dfusionService.watchOrderPlacement({
       buyToken
     )
 
-    // Only display the valid from if the period hasn't started
-    const now = new Date()
-    let datesDescription = ''
-    if (validFrom > now) {
-      // The order is not active yet
-      datesDescription = `  - *Tradable*: \`${moment(validFrom).calendar()} GMT\`, \`${moment(validFrom).fromNow()}\`\n`
-    }
-    datesDescription += `  - *Expires*: \`${moment(validUntil).calendar()} GMT\`, \`${moment(validUntil).fromNow()}\``
-
     // Format the amounts
     // TODO: Allow to use BN, string or BigNumber or all three in the format. Review in dex-js
     const fillSellAmountFmt = formatAmountFull(
@@ -184,12 +175,23 @@ dfusionService.watchOrderPlacement({
 
     // TODO: Should we publish even if the user doesn't have balance. Should we include the balance of the user? he can change it...
     //  https://github.com/gnosis/dex-telegram/issues/45
-    const message = `Sell *${sellAmountFmt}* \`${sellTokenLabel}\` for *${buyAmountFmt}* \`${buyTokenLabel}\`
+    let message = `Sell *${sellAmountFmt}* \`${sellTokenLabel}\` for *${buyAmountFmt}* \`${buyTokenLabel}\`\n`
+    message += `\n  - *Price*:  1 \`${sellTokenLabel}\` = ${price} \`${buyTokenLabel}\``
 
-  - *Price*:  1 \`${sellTokenLabel}\` = ${price} \`${buyTokenLabel}\`
-${datesDescription}
-
-Fill the order here: ${WEB_BASE_URL}/trade/${sellTokenParam}-${buyTokenParam}?sell=${fillSellAmountFmt}&buy=${buyAmountFullFmt}`
+    // Only display the valid from if the period hasn't started
+    const now = new Date()
+    if (validFrom > now) {
+      // The order is not active yet
+      message += `\n  - *Tradable*: \`${moment(validFrom).calendar()} GMT\`, \`${moment(validFrom).fromNow()}\``
+    }
+    message += `\n  - *Expires*: \`${moment(validUntil).calendar()} GMT\`, \`${moment(validUntil).fromNow()}\``
+    if (!sellToken.known || !buyToken.known) {
+      message +=
+        '\n  - "Maybe <token-symbol>" means the token is not recognizable as a token in the following [web](' +
+        WEB_BASE_URL +
+        ')'
+    }
+    message += `\n\nFill the order here: ${WEB_BASE_URL}/trade/${sellTokenParam}-${buyTokenParam}?sell=${fillSellAmountFmt}&buy=${buyAmountFullFmt}`
 
     // Send message
     bot.sendMessage(channelId, message, { parse_mode: 'Markdown' })

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,12 +1,13 @@
 import assert from 'assert'
 import moment from 'moment-timezone'
 import TelegramBot, { Message, User } from 'node-telegram-bot-api'
+import BigNumber from 'bignumber.js'
+import BN from 'bn.js'
 
 import Logger from 'helpers/Logger'
 import { logUnhandledErrors, onShutdown } from 'helpers'
-import { dfusionService } from 'services'
+import { dfusionService, TokenDto } from 'services'
 import { formatAmount, formatAmountFull } from 'utils/format'
-import BN from 'bn.js'
 import { FEE_DENOMINATOR } from 'const'
 
 const WEB_BASE_URL = process.env.WEB_BASE_URL
@@ -110,6 +111,24 @@ Also, here are some links you might find useful:
   )
 }
 
+function _getTokenFmt (amount: BigNumber, token: TokenDto) {
+  let tokenLabel, tokenParam
+  if (token.known) {
+    tokenLabel = token.symbol || token.name || token.address
+    tokenParam = tokenLabel
+  } else {
+    // The token is unknown, so it can't be trusted.
+    // We use it's address and we add the "Maybe " prefix ot it's symbol/name
+    const tokenLabelAux = token.symbol || token.name
+    tokenLabel = tokenLabelAux ? 'Maybe ' + tokenLabelAux : token.address
+    tokenParam = token.address
+  }
+
+  const amountFmt = formatAmount(new BN(amount.toString()), token.decimals)
+
+  return { tokenLabel, tokenParam, amountFmt }
+}
+
 dfusionService.watchOrderPlacement({
   onNewOrder (order) {
     const {
@@ -137,8 +156,14 @@ dfusionService.watchOrderPlacement({
 
     // Label for token
     // TODO: to use the shared utils function when available safeTokenName
-    const sellTokenLabel = sellToken.symbol || sellToken.name || sellToken.address
-    const buyTokenLabel = buyToken.symbol || buyToken.name || buyToken.address
+    const { tokenLabel: sellTokenLabel, tokenParam: sellTokenParam, amountFmt: sellAmountFmt } = _getTokenFmt(
+      priceDenominator,
+      sellToken
+    )
+    const { tokenLabel: buyTokenLabel, tokenParam: buyTokenParam, amountFmt: buyAmountFmt } = _getTokenFmt(
+      priceNumerator,
+      buyToken
+    )
 
     // Only display the valid from if the period hasn't started
     const now = new Date()
@@ -151,23 +176,20 @@ dfusionService.watchOrderPlacement({
 
     // Format the amounts
     // TODO: Allow to use BN, string or BigNumber or all three in the format. Review in dex-js
-    const sellAmountFmt = formatAmount(new BN(priceDenominator.toString()), sellToken.decimals)
-    const buyAmountFmt = formatAmount(new BN(priceNumerator.toString()), buyToken.decimals)
     const fillSellAmountFmt = formatAmountFull(
       new BN(priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).toString()),
       buyToken.decimals
     )
     const buyAmountFullFmt = formatAmountFull(new BN(priceDenominator.toString()), sellToken.decimals)
 
-    // Compose message using markdown
-    // TODO: Provide the link to the front end: https://github.com/gnosis/dex-telegram/issues/3
     // TODO: Should we publish even if the user doesn't have balance. Should we include the balance of the user? he can change it...
+    //  https://github.com/gnosis/dex-telegram/issues/45
     const message = `Sell *${sellAmountFmt}* \`${sellTokenLabel}\` for *${buyAmountFmt}* \`${buyTokenLabel}\`
 
   - *Price*:  1 \`${sellTokenLabel}\` = ${price} \`${buyTokenLabel}\`
 ${datesDescription}
 
-Fill the order here: ${WEB_BASE_URL}/trade/${buyTokenLabel}-${sellTokenLabel}?sell=${fillSellAmountFmt}&buy=${buyAmountFullFmt}` // TODO:
+Fill the order here: ${WEB_BASE_URL}/trade/${sellTokenParam}-${buyTokenParam}?sell=${fillSellAmountFmt}&buy=${buyAmountFullFmt}`
 
     // Send message
     bot.sendMessage(channelId, message, { parse_mode: 'Markdown' })

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -115,7 +115,7 @@ function _getTokenFmt (amount: BigNumber, token: TokenDto) {
   let tokenLabel, tokenParam
   if (token.known) {
     tokenLabel = token.symbol || token.name || token.address
-    tokenParam = tokenLabel
+    tokenParam = token.symbol || token.address
   } else {
     // The token is unknown, so it can't be trusted.
     // We use it's address and we add the "Maybe " prefix ot it's symbol/name

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -32,14 +32,15 @@ export interface WatchOrderPlacementParams {
   onError: (error: Error) => void
 }
 
-interface TokenDto {
+export interface TokenDto {
   name?: string
   symbol?: string
   decimals: number
   address: string
+  known: boolean
 }
 
-interface AboutDto {
+export interface AboutDto {
   blockNumber: number
   networkId: number
   nodeInfo: string
@@ -190,7 +191,8 @@ export class DfusionRepoImpl implements DfusionService {
         name,
         ...tokenJson,
         decimals: decimals as number,
-        address: tokenAddress
+        address: tokenAddress,
+        known: !!tokenJson
       }
 
       // Cache token if it's found, or null if is not
@@ -224,7 +226,6 @@ async function _getDataFromErc20 (tokenContract: Erc20Contract) {
   const symbolPromise = tokenContract.methods
     .symbol()
     .call()
-    .then(symbol => 'Maybe ' + symbol)
     .catch(() => undefined)
 
   const decimalsPromise = tokenContract.methods
@@ -236,7 +237,6 @@ async function _getDataFromErc20 (tokenContract: Erc20Contract) {
   const namePromise = tokenContract.methods
     .name()
     .call()
-    .then(name => 'Maybe ' + name)
     .catch(() => undefined)
 
   // Get basic data from the contract

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,3 +12,6 @@ function createDfusionService (): DfusionService {
 
 // Build Repos
 export const dfusionService: DfusionService = createDfusionService()
+
+// Reexport all definitions
+export * from './DfusionService'


### PR DESCRIPTION
The current version doesn't handle properly the tokens that are unknown.

We define `unknown`, for this project and for the current state/scope as a token that doesn't belong to the list in the front end. This criteria might envelope and probably will use TCRs or other methods to define what is known/unknown

In anycase, unknown may be a token with a familiar symbol (i.e. DAI) but whose address is not recognizable. So it's a threat

The telegram bot will flag this tokens as "Maybe <name of token>"

This PRs improves the URL generation for the frontend, and in this situations we use the address instead of the symbol. Also it adds a small refactor to avoid replicating the logic so much for the sellToken and buyToken.


Unknown tokens and their URL might look like this:
![image](https://user-images.githubusercontent.com/2352112/70082890-a6604600-160b-11ea-8128-33e08ab6fb96.png)

