### PR TITLE
Liveness endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN yarn build
 # Use telegram user
 USER telegram
 
+# Expose container port
+EXPOSE 3000
+
 # Run Node app as child of tini
 # Signal handling for PID1 https://github.com/krallin/tini
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ By default, the API is exposed in port `3000`, but it can be changed using `API_
 The endpoints using the default port would be available at:
 
 - http://localhost:3000/v1/health/ping
-- http://localhost:3000/v1/health/ping
+- http://localhost:3000/v1/health/healthy

--- a/README.md
+++ b/README.md
@@ -69,3 +69,14 @@ yarn build
 # Run
 yarn start
 ```
+
+## liveness probes
+
+The app will expose two endpoints to verify the liveness of it.
+
+By default, the API is exposed in port `3000`, but it can be changed using `API_PORT` environment var.
+
+The endpoints using the default port would be available at:
+
+- http://localhost:3000/v1/health/ping
+- http://localhost:3000/v1/health/ping

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,7 @@ version: '3'
 services:
   telegram:
     build: .
+    ports:
+      - '3000:3000'
     env_file:
-    - .env
+      - .env

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",
+    "express": "^4.17.1",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "node-telegram-bot-api": "^0.30.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/dotenv": "^8.2.0",
+    "@types/express": "^4.17.2",
     "@types/jest": "^24.0.22",
     "@types/moment-timezone": "^0.5.12",
     "@types/node": "^12.7.5",

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -43,7 +43,7 @@ export class Server {
       server.listen(this._port, () => {
         log.debug(`Server started on port ${this._port}!`)
         log.debug(`Ping URL: http://localhost:${this._port}/v1/health/ping`)
-        log.debug(`Alive URL: http://localhost:${this._port}/v1/health/alive`)
+        log.debug(`Alive URL: http://localhost:${this._port}/v1/health/healthy`)
         resolve()
       })
     })

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import express, { Express } from 'express'
+import * as http from 'http'
+
+import Logger from 'helpers/Logger'
+import { Request, ParamsDictionary, Response, NextFunction } from 'express-serve-static-core'
+
+const log = new Logger('server')
+export interface Params {
+  port: number
+}
+
+export class Server {
+  private _port: number
+  private _server: http.Server | null = null
+
+  constructor (params: Params) {
+    const { port } = params
+    this._port = port
+  }
+
+  public start (): Promise<void> {
+    assert(this._server === null, 'Server was already started')
+    const app = express()
+
+    // Register endpoints
+    this._registerEndpoint(app)
+
+    // Register middleware
+    this._registerMiddleware(app)
+
+    // Create server
+    this._server = http.createServer(app)
+    const server = this._server as http.Server
+
+    // Start to listen on port
+    return new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(this._port, () => {
+        log.debug(`Listening on port ${this._port}!`)
+        log.debug(`Ping URL: http://localhost:${this._port}/v1/health/ping`)
+        log.debug(`Alive URL: http://localhost:${this._port}/v1/health/alive`)
+        resolve()
+      })
+    })
+  }
+
+  private _registerEndpoint (app: Express) {
+    app.get('/v1/health/ping', (_req, res) => res.status(204).send())
+    app.get('/v1/health/alive', (_req, res) => res.status(204).send())
+  }
+
+  private _registerMiddleware (app: Express) {
+    app.use((err: Error, req: Request<ParamsDictionary, any, any>, res: Response<any>, _next: NextFunction) => {
+      log.error(`Error ${req.method} ${req.url}`, err)
+      res.status(500).send({ error: true, message: err.message, stack: err.stack })
+    })
+  }
+
+  public stop () {
+    this._server = null
+  }
+}
+
+export default Server

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -50,10 +50,8 @@ export class Server {
   }
 
   private _registerEndpoint (app: Express) {
-    app.get('/v1/health/ping', (_req, _res) => {
-      throw new Error('ping pong')
-    })
-    app.get('/v1/health/alive', (req, res) => res.send('Alive ' + req.url))
+    app.get('/v1/health/ping', (_req, res) => res.status(204).send())
+    app.get('/v1/health/healthy', (_req, res) => res.status(204).send())
   }
 
   private _registerMiddleware (app: Express) {

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -39,7 +39,7 @@ export class Server {
       server.listen(this._port, () => {
         log.debug(`Listening on port ${this._port}!`)
         log.debug(`Ping URL: http://localhost:${this._port}/v1/health/ping`)
-        log.debug(`Alive URL: http://localhost:${this._port}/v1/health/alive`)
+        log.debug(`Healthy URL: http://localhost:${this._port}/v1/health/healthy`)
         resolve()
       })
     })
@@ -47,7 +47,7 @@ export class Server {
 
   private _registerEndpoint (app: Express) {
     app.get('/v1/health/ping', (_req, res) => res.status(204).send())
-    app.get('/v1/health/alive', (_req, res) => res.status(204).send())
+    app.get('/v1/health/healthy', (_req, res) => res.status(204).send())
   }
 
   private _registerMiddleware (app: Express) {

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -4,6 +4,7 @@ import * as http from 'http'
 
 import Logger from 'helpers/Logger'
 import { Request, ParamsDictionary, Response, NextFunction } from 'express-serve-static-core'
+import { addCache, noCache } from 'helpers'
 
 const log = new Logger('server')
 export interface Params {
@@ -50,11 +51,23 @@ export class Server {
   }
 
   private _registerEndpoint (app: Express) {
-    app.get('/v1/health/ping', (_req, res) => res.status(204).send())
-    app.get('/v1/health/healthy', (_req, res) => res.status(204).send())
+    app.get('/v1/version', (_req, res) => {
+      addCache(res, 120)
+      res.status(200).send('0.0.1') // TODO: next PR
+    })
+
+    app.get('/v1/health/ping', (_req, res) => {
+      noCache(res)
+      res.status(204).send()
+    })
+    app.get('/v1/health/healthy', (_req, res) => {
+      noCache(res)
+      res.status(204).send()
+    })
   }
 
   private _registerMiddleware (app: Express) {
+    // Handle errors
     app.use((error: Error, req: Request<ParamsDictionary, any, any>, res: Response<any>, _next: NextFunction) => {
       log.error(`Error ${req.method} ${req.url}`, error)
       res.status(500).send({ error: true, message: error.message, stack: error.stack })

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import moment from 'moment-timezone'
 import TelegramBot, { Message, User } from 'node-telegram-bot-api'
+import Server from 'Server'
 
 import Logger from 'helpers/Logger'
 import { logUnhandledErrors, onShutdown } from 'helpers'
@@ -11,6 +12,7 @@ import { FEE_DENOMINATOR } from 'const'
 
 const WEB_BASE_URL = process.env.WEB_BASE_URL
 assert(WEB_BASE_URL, 'WEB_BASE_URL is required')
+const port = parseInt(process.env.API_PORT || '3000')
 
 // To fill an order, no solver will match the trades if there's not 2*FEE spread between the trades
 const FACTOR_TO_FILL_ORDER = 1 + 2 / FEE_DENOMINATOR
@@ -189,4 +191,11 @@ dfusionService
       `'Using contract ${stablecoinConverterAddress} in network ${networkId} (${nodeInfo}). Last block: ${blockNumber}'`
     )
   })
+  .catch(log.errorHandler)
+
+// Run server
+const server = new Server({ port })
+server
+  .start()
+  .then(() => log.info('Server is running on port %d', port))
   .catch(log.errorHandler)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -54,10 +54,6 @@ bot.on('message', (msg: Message) => {
   }
 })
 
-onShutdown(() => {
-  log.info('Bye!')
-})
-
 async function _runCommand (msg: Message, match: RegExpExecArray | null) {
   const command = match ? match[1] : ''
   switch (command) {
@@ -197,5 +193,14 @@ dfusionService
 const server = new Server({ port })
 server
   .start()
-  .then(() => log.info('Server is running on port %d', port))
+  .then(() => log.info('Server is ready on port %d', port))
   .catch(log.errorHandler)
+
+onShutdown(async () => {
+  // Stop server
+  await server
+    .stop()
+    .then(() => log.info('Server has been stopped'))
+    .catch(log.errorHandler)
+    .finally(() => log.info('Bye!'))
+})

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,0 +1,9 @@
+import { Response } from 'express-serve-static-core'
+
+export function addCache (res: Response<any>, maxAge: number) {
+  res.set('Cache-Control', 'public, max-age=' + maxAge)
+}
+
+export function noCache (res: Response<any>) {
+  res.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './shutdown'
 export * from './error'
+export * from './http'

--- a/src/helpers/shutdown.ts
+++ b/src/helpers/shutdown.ts
@@ -1,5 +1,5 @@
 import Logger from 'helpers/Logger'
-import { Command } from 'types'
+import { Command, AsyncCommand } from 'types'
 
 const log = new Logger('helpers:shutdown')
 type QuitSignal = 'SIGINT' | 'SIGTERM' | 'SIGQUIT'
@@ -13,7 +13,7 @@ POSIX_SIGNALS.forEach(signal => {
   })
 })
 
-export function onShutdown (listener: Command) {
+export function onShutdown (listener: Command | AsyncCommand) {
   log.debug('Registering a new listener')
   listeners.push(listener)
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export type Command = () => void
+export type AsyncCommand = () => Promise<void>
 
 export interface TokenDetails {
   name?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3881,7 +3881,7 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
-express@^4.14.0:
+express@^4.14.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,10 +700,25 @@
   dependencies:
     "@types/node" "*"
 
+"@types/body-parser@*":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.1.tgz#18fcf61768fb5c30ccc508c21d6fd2e8b3bf7897"
+  integrity sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/caseless@*":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
+"@types/connect@*":
+  version "3.4.32"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
+  integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/debug@^4.1.5":
   version "4.1.5"
@@ -721,6 +736,23 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/express-serve-static-core@*":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.0.tgz#e80c25903df5800e926402b7e8267a675c54a281"
+  integrity sha512-Xnub7w57uvcBqFdIGoRg1KhNOeEj0vB6ykUM7uFWyxvbdE89GFyqgmUcanAriMr4YOxNFZBAWkfcWIb4WBPt3g==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.2":
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.2.tgz#a0fb7a23d8855bac31bc01d5a58cadd9b2173e6c"
+  integrity sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
@@ -758,6 +790,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
 
 "@types/mkdirp@^0.5.2":
   version "0.5.2"
@@ -811,6 +848,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
 "@types/react-dom@*":
   version "16.9.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
@@ -858,6 +900,14 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/serve-static@*":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
**Includes**:
* Express integration
* Create a Server class with start/stop methods
* Run the Server
* Add 2 liveness endpoints

**A bit of context**:
Currently there's a problem if the Websocket connection is broken, or the bot become unavailable for whatever reason.

If this happens, kubernetes has not mean to know if it's still responsive.

For this reason, this PR creates 2 basic endpoints:
* *Ping*: Just to check the server is up and responsing
* *Healthy*: Just do some additional checks, like we are correctly connected to the ethereum node. (`important`: it has a trivial implementation. Real one will come in a different PR)

Kubernetes will use this to detect problems and restart the bot automatically

Logs any error:
![image](https://user-images.githubusercontent.com/2352112/70165193-c43cb200-16c2-11ea-9a3e-9f32307bba84.png)

Any error in the endpoint will return a JSON error decribing the problem, on top of loggin it in the console:
![image](https://user-images.githubusercontent.com/2352112/70165369-1978c380-16c3-11ea-8d35-a37800250b99.png)



*Test* with CURL, both endpoints should return a `204`:
![image](https://user-images.githubusercontent.com/2352112/70165121-a8391080-16c2-11ea-927a-d00561f336dd.png)

