### PR TITLE
Liveness endpoint impl

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.4",
   "description": "",
   "scripts": {
-    "start": "DEBUG=ERROR-*,WARN-*,INFO-* node build/src/bot",
-    "start:env": "DEBUG=ERROR-*,WARN-*,INFO-* node -r dotenv/config build/src/bot",
-    "dev": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-*,-DEBUG-helper*,-DEBUG-util* nodemon -r dotenv/config  -r tsconfig-paths/register src/bot.ts",
+    "start": "DEBUG=ERROR-*,WARN-*,INFO-* NTBA_FIX_319=yes node build/src/bot",
+    "start:env": "DEBUG=ERROR-*,WARN-*,INFO-* NTBA_FIX_319=yes node -r dotenv/config build/src/bot",
+    "dev": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-*,-DEBUG-helper*,-DEBUG-util* NTBA_FIX_319=yes nodemon -r dotenv/config  -r tsconfig-paths/register src/bot.ts",
     "dev:debug": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-* -r dotenv/config -r tsconfig-paths/register src/bot.ts",
     "dev:info": "DEBUG=ERROR-*,WARN-*,INFO-* nodemon -r tsconfig-paths/register -r dotenv/config src/bot.ts",
     "sandbox": "DEBUG=ERROR-*,WARN-*,INFO-*,DEBUG-*,-DEBUG-helper*,-DEBUG-util* nodemon -r dotenv/config -r tsconfig-paths/register",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -212,7 +212,7 @@ dfusionService
   .catch(log.errorHandler)
 
 // Run server
-const server = new Server({ port })
+const server = new Server({ port, dfusionService })
 server
   .start()
   .then(() => log.info('Server is ready on port %d', port))

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -25,6 +25,7 @@ export interface DfusionService {
   // Basic info
   getAbout(): Promise<AboutDto>
   getVersion(): String
+  isHealthy(): Promise<boolean>
 }
 
 export interface WatchOrderPlacementParams {
@@ -76,6 +77,10 @@ export class DfusionRepoImpl implements DfusionService {
     this._contract = stableCoinConverterContract
     this._erc20Contract = erc20Contract
     this._web3 = web3
+  }
+
+  public async isHealthy (): Promise<boolean> {
+    return true
   }
 
   public watchOrderPlacement (params: WatchOrderPlacementParams) {


### PR DESCRIPTION
Second PR for the liveness probe for kubernetes. See first one here #49 

This implements the logic for the health check.

It will:
* Check for connectivity
* Peer counts: Error if it's 0, warning if it's low
* last minted block. Error if there's no recent blocks


