### PR TITLE
Make use of the constructors in dex-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@gnosis.pm/dex-js": "0.1.5-RC.3",
+    "@gnosis.pm/dex-js": "0.1.6",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@gnosis.pm/dex-js": "0.1.4",
+    "@gnosis.pm/dex-js": "0.1.5-RC.3",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",

--- a/src/helpers/contracts.ts
+++ b/src/helpers/contracts.ts
@@ -1,0 +1,5 @@
+import { createBatchExchangeContract, createErc20Contract } from '@gnosis.pm/dex-js'
+import { web3 } from './web3'
+
+export const batchExchangeContract = createBatchExchangeContract(web3)
+export const erc20Contract = createErc20Contract(web3)

--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -1,0 +1,3 @@
+import { createWeb3 } from '@gnosis.pm/dex-js'
+
+export const web3 = createWeb3()

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,5 @@
-import { web3 } from '@gnosis.pm/dex-js/build/helpers/web3'
-import { batchExchangeContract, erc20Contract } from '@gnosis.pm/dex-js/build/contracts'
+import { batchExchangeContract, erc20Contract } from 'helpers/contracts'
+import { web3 } from 'helpers/web3'
 
 import DfusionServiceImpl, { DfusionService } from 'services/DfusionService'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,20 +138,19 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@gnosis.pm/dex-contracts@^0.1.3":
+"@gnosis.pm/dex-contracts@^0.1.2":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.1.3.tgz#8474ed83c879a3c3a22ce13741e3ad43dac6dd68"
   integrity sha512-HRRw+AGZYe6almCQRj8pNL1AELLnkvB1jqLs20faaoISy+5f9I4nsgHbkw9qzxi/R8NQ8pAc/wIx4rvH7hSeCw==
   dependencies:
     bn.js "^5.0.0"
 
-"@gnosis.pm/dex-js@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.4.tgz#315863df63f104871850123982c74435409975bd"
-  integrity sha512-qKw588hsupYOUT14ZcajCsULFWIHlCvwPcI5s7MhxfwaylQLB6WHz9AUwoy3xZFJD1E1zd4vt7BpuCkIQN2S7w==
+"@gnosis.pm/dex-js@0.1.5-RC.3":
+  version "0.1.5-RC.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.5-RC.3.tgz#34cdd68dc388258071191b21beaf74469b5057f7"
+  integrity sha512-ywEebwtT8zLC8Mmo53AmtWBTgca9l+vYby3A4IlR46Vs2Fk5TDgDMgzQlnE8LMZObozY34iz5Q/cq4oeONq9KQ==
   dependencies:
-    "@gnosis.pm/dex-contracts" "^0.1.3"
-    web3 "^1.2.4"
+    "@gnosis.pm/dex-contracts" "^0.1.2"
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,10 +145,10 @@
   dependencies:
     bn.js "^5.0.0"
 
-"@gnosis.pm/dex-js@0.1.5-RC.3":
-  version "0.1.5-RC.3"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.5-RC.3.tgz#34cdd68dc388258071191b21beaf74469b5057f7"
-  integrity sha512-ywEebwtT8zLC8Mmo53AmtWBTgca9l+vYby3A4IlR46Vs2Fk5TDgDMgzQlnE8LMZObozY34iz5Q/cq4oeONq9KQ==
+"@gnosis.pm/dex-js@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.6.tgz#c7d732a522ed36d36a33addb4ac727546a3c0a1e"
+  integrity sha512-KkB7qECUi5CPcQckY/wjYEL3zl2hY05hQjd7ZGArX7UvsPoeynO4droXKC/999cfBZgYEVqDxpcEfYTpZI8mAw==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.1.2"
 


### PR DESCRIPTION
Adapts to https://github.com/gnosis/dex-js/pull/44 

Allows to get rid of the `@gnosis.pm/dex-js/build/src/bla/bla` routes.
We use the constructors instead of the instances in dex-js.