### PR TITLE
436/unlimited orders now with tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     commonjs: true,
     es6: true,
     node: true,
+    jest: true,
   },
   extends: ['standard'],
   globals: {},

--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -1,4 +1,5 @@
 import BN from 'bn.js'
+import BigNumber from 'bignumber.js'
 import moment from 'moment-timezone'
 
 import {
@@ -8,8 +9,7 @@ import {
   isOrderUnlimited,
   isNeverExpiresOrder,
 } from '@gnosis.pm/dex-js'
-import BigNumber from 'bignumber.js'
-import { TokenDto } from 'services'
+import { TokenDto, OrderDto } from 'services'
 
 // To fill an order, no solver will match the trades if there's not 2*FEE spread between the trades
 const FACTOR_TO_FILL_ORDER = 1 + 2 / FEE_DENOMINATOR
@@ -27,34 +27,109 @@ function _getTokenFmt(amount: BigNumber, token: TokenDto) {
     tokenParam = token.address
   }
 
-  const amountFmt = formatAmount(new BN(amount.toString()), token.decimals)
+  const amountFmt = formatAmount(new BN(amount.toString()), token.decimals) as string
 
   return { tokenLabel, tokenParam, amountFmt }
 }
 
-export function newOrderMessage(order: any, baseUrl: string): string {
-  const {
-    // owner,
-    buyToken,
-    sellToken,
-    validFrom,
-    validUntil,
-    // validFromBatchId,
-    // validUntilBatchId,
-    priceNumerator,
-    priceDenominator,
-    // event
-  } = order
+// TODO: probably there is (or there should be) a function shared on dex-js for this
+export function calculatePrice(order: OrderDto): BigNumber {
+  const { buyToken, sellToken, priceNumerator, priceDenominator } = order
 
-  // Calculate the price
-  let price
   if (buyToken.decimals >= sellToken.decimals) {
     const precisionFactor = 10 ** (buyToken.decimals - sellToken.decimals)
-    price = priceNumerator.dividedBy(priceDenominator.multipliedBy(precisionFactor))
+    return priceNumerator.dividedBy(priceDenominator.multipliedBy(precisionFactor))
   } else {
     const precisionFactor = 10 ** (sellToken.decimals - buyToken.decimals)
-    price = priceNumerator.multipliedBy(precisionFactor).dividedBy(priceDenominator)
+    return priceNumerator.multipliedBy(precisionFactor).dividedBy(priceDenominator)
   }
+}
+
+export function buildExpirationMsg(order: OrderDto): string {
+  const { validUntilBatchId, validUntil } = order
+
+  if (isNeverExpiresOrder(validUntilBatchId.toNumber())) {
+    return '\n  - *Expires*: Valid until cancelled'
+  } else {
+    return `\n  - *Expires*: \`${moment(validUntil).calendar()} GMT\`, \`${moment(validUntil).fromNow()}\``
+  }
+}
+
+export function buildUnknownTokenMsg(order: OrderDto): string {
+  const { buyToken, sellToken } = order
+
+  if (!sellToken.known || !buyToken.known) {
+    return (
+      '\n  - "Maybe" means one or more tokens claim to be called as shown, ' +
+      "but it's not currently part of the list of [known tokens](https://github.com/gnosis/dex-js/blob/master/src/tokenList.json). " +
+      'Make sure you verify the address yourself before trading against it.'
+    )
+  } else {
+    return ''
+  }
+}
+
+export function buildNotYetActiveOrderMsg(validFrom: Date): string {
+  const now = new Date()
+
+  if (validFrom > now) {
+    // The order is not active yet
+    return `\n  - *Tradable*: \`${moment(validFrom).calendar()} GMT\`, \`${moment(validFrom).fromNow()}\``
+  } else {
+    return ''
+  }
+}
+
+export function buildSellMsg(
+  isUnlimited: boolean,
+  buyTokenLabel: string,
+  sellTokenLabel: string,
+  buyAmount: string,
+  sellAmount: string,
+): string {
+  if (isUnlimited) {
+    // doesn't make sense to display amounts when the order is unlimited
+    return `Sell \`${sellTokenLabel}\` for \`${buyTokenLabel}\`\n`
+  } else {
+    return `Sell *${sellAmount}* \`${sellTokenLabel}\` for *${buyAmount}* \`${buyTokenLabel}\`\n`
+  }
+}
+
+export function buildFillOrderMsg(
+  isUnlimited: boolean,
+  order: OrderDto,
+  price: BigNumber,
+  baseUrl: string,
+  buyTokenParam: string,
+  sellTokenParam: string,
+): string {
+  const { buyToken, priceDenominator, sellToken, priceNumerator } = order
+
+  let fillAmountBuy: string
+  let fillAmountSell: string
+  if (isUnlimited) {
+    // This is tricky. how much should we offer to fill for a unlimited order?
+    // Going for 10 units
+    fillAmountBuy = '10'
+    fillAmountSell = price
+      .multipliedBy(10)
+      .multipliedBy(FACTOR_TO_FILL_ORDER)
+      .toString(10)
+  } else {
+    // Format the amounts
+    // TODO: Allow to use BN, string or BigNumber or all three in the format. Review in dex-js
+    fillAmountBuy = formatAmountFull(new BN(priceDenominator.toString()), sellToken.decimals) as string
+    fillAmountSell = formatAmountFull(
+      new BN(priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).toString()),
+      buyToken.decimals,
+    ) as string
+  }
+
+  return `\n\nFill the order here: ${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}?sell=${fillAmountSell}&buy=${fillAmountBuy}`
+}
+
+export function newOrderMessage(order: OrderDto, baseUrl: string): string {
+  const { buyToken, sellToken, validFrom, priceNumerator, priceDenominator } = order
 
   // Label for token
   // TODO: to use the shared utils function when available safeTokenName
@@ -70,62 +145,23 @@ export function newOrderMessage(order: any, baseUrl: string): string {
   // unlimited?
   const isUnlimited = isOrderUnlimited(priceNumerator, priceDenominator)
 
-  // Format the amounts
-  // TODO: Allow to use BN, string or BigNumber or all three in the format. Review in dex-js
-  const fillSellAmountFmt = formatAmountFull(
-    new BN(priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).toString()),
-    buyToken.decimals,
-  )
-  const buyAmountFullFmt = formatAmountFull(new BN(priceDenominator.toString()), sellToken.decimals)
-
   // TODO: Should we publish even if the user doesn't have balance. Should we include the balance of the user? he can change it...
   //  https://github.com/gnosis/dex-telegram/issues/45
-  let sellMsg: string
-  if (isUnlimited) {
-    sellMsg = `Sell \`${sellTokenLabel}\` for \`${buyTokenLabel}\``
-  } else {
-    sellMsg = `Sell *${sellAmountFmt}* \`${sellTokenLabel}\` for *${buyAmountFmt}* \`${buyTokenLabel}\`\n`
-  }
 
-  let message = sellMsg
-
-  message += `\n  - *Price*:  1 \`${sellTokenLabel}\` = ${price} \`${buyTokenLabel}\``
-
+  const sellMsg = buildSellMsg(isUnlimited, buyTokenLabel, sellTokenLabel, buyAmountFmt, sellAmountFmt)
+  // Calculate the price
+  const price = calculatePrice(order)
+  const priceMsg = `\n  - *Price*:  1 \`${sellTokenLabel}\` = ${price} \`${buyTokenLabel}\``
   // Only display the valid from if the period hasn't started
-  const now = new Date()
-  if (validFrom > now) {
-    // The order is not active yet
-    message += `\n  - *Tradable*: \`${moment(validFrom).calendar()} GMT\`, \`${moment(validFrom).fromNow()}\``
-  }
-
+  const notYetActiveOrderMsg = buildNotYetActiveOrderMsg(validFrom)
   // Does it expire?
-  const isNeverExpires = isNeverExpiresOrder(validUntil)
+  const expirationMsg = buildExpirationMsg(order)
+  // In case one of the tokens is not in our list
+  const unknownTokenMsg = buildUnknownTokenMsg(order)
+  // Create link for filling this order
+  const fillOrderMsg = buildFillOrderMsg(isUnlimited, order, price, baseUrl, buyTokenParam, sellTokenParam)
 
-  let expirationMsg: string
-  if (isNeverExpires) {
-    expirationMsg = '\n  - *Expires*: Valid until cancelled'
-  } else {
-    expirationMsg = `\n  - *Expires*: \`${moment(validUntil).calendar()} GMT\`, \`${moment(validUntil).fromNow()}\``
-  }
-  message += expirationMsg
-
-  if (!sellToken.known || !buyToken.known) {
-    message +=
-      '\n  - "Maybe" means one or more tokens claim to be called as shown, ' +
-      "but it's not currently part of the list of [known tokens](https://github.com/gnosis/dex-js/blob/master/src/tokenList.json). " +
-      'Make sure you verify the address yourself before trading against it.'
-  }
-
-  let fillAmountBuy: string
-  let fillAmountSell: string
-  if (isUnlimited) {
-    fillAmountBuy = '10'
-    fillAmountSell = price.multipliedBy(10).multipliedBy(FACTOR_TO_FILL_ORDER)
-  } else {
-    fillAmountBuy = buyAmountFullFmt as string
-    fillAmountSell = fillSellAmountFmt as string
-  }
-  message += `\n\nFill the order here: ${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}?sell=${fillAmountSell}&buy=${fillAmountBuy}`
+  const message = `${sellMsg}${priceMsg}${notYetActiveOrderMsg}${expirationMsg}${unknownTokenMsg}${fillOrderMsg}`
 
   return message
 }

--- a/test/helpers/message.spec.ts
+++ b/test/helpers/message.spec.ts
@@ -1,0 +1,141 @@
+import BigNumber from 'bignumber.js'
+
+import { OrderDto } from 'services'
+import {
+  calculatePrice,
+  buildExpirationMsg,
+  buildUnknownTokenMsg,
+  buildNotYetActiveOrderMsg,
+  buildSellMsg,
+  buildFillOrderMsg,
+} from 'helpers'
+import { MAX_BATCH_ID } from '@gnosis.pm/dex-js'
+
+const MockEvent = jest.fn()
+
+const baseBuyToken = { decimals: 18, address: '0x', known: true }
+const baseSellToken = { decimals: 18, address: '0x', known: true }
+const baseOrder: OrderDto = {
+  owner: '0x',
+  buyToken: baseBuyToken,
+  sellToken: baseSellToken,
+  priceNumerator: new BigNumber(10),
+  priceDenominator: new BigNumber(10),
+  validFrom: new Date(),
+  validUntil: new Date(),
+  validFromBatchId: new BigNumber(0),
+  validUntilBatchId: new BigNumber(1),
+  event: new MockEvent(),
+}
+
+describe('calculatePrice', () => {
+  test('buy token with same or higher precision', () => {
+    const actual = calculatePrice(baseOrder)
+
+    expect(actual.toString(10)).toBe('1')
+  })
+
+  test('sell token with higher precision', () => {
+    const order = { ...baseOrder, buyToken: { ...baseBuyToken, decimals: 17 } }
+
+    const actual = calculatePrice(order)
+
+    expect(actual.toString(10)).toBe('10')
+  })
+})
+
+describe('buildExpirationMsg', () => {
+  test('With expiration', () => {
+    const actual = buildExpirationMsg(baseOrder)
+
+    expect(actual).toMatch(/\*Expires\*: `.+ GMT`, `.+`/)
+  })
+
+  test('Without expiration', () => {
+    const order = { ...baseOrder, validUntilBatchId: new BigNumber(MAX_BATCH_ID) }
+
+    const actual = buildExpirationMsg(order)
+
+    expect(actual).toMatch(/\*Expires\*: Valid until cancelled/)
+  })
+})
+
+describe('buildUnknownTokenMsg', () => {
+  test('No unknown tokens', () => {
+    const actual = buildUnknownTokenMsg(baseOrder)
+
+    expect(actual).toBe('')
+  })
+
+  test('With unknown tokens', () => {
+    const order = { ...baseOrder, sellToken: { ...baseSellToken, known: false } }
+
+    const actual = buildUnknownTokenMsg(order)
+
+    // No need to check the whole message
+    expect(actual).toMatch(/"Maybe" means one or more tokens/)
+  })
+})
+
+describe('buildNotYetActiveOrderMsg', () => {
+  test('Active order', () => {
+    const actual = buildNotYetActiveOrderMsg(new Date(0))
+
+    expect(actual).toBe('')
+  })
+
+  test('Not yet active order', () => {
+    const validFrom = new Date(new Date().getTime() + 10000)
+
+    const active = buildNotYetActiveOrderMsg(validFrom)
+
+    expect(active).toMatch(/\*Tradable\*: `.+ GMT`, `.+`/)
+  })
+})
+
+describe('buildSellMsg', () => {
+  const buyTokenLabel = 'SCM'
+  const sellTokenLabel = 'PMD'
+
+  test('unlimited order', () => {
+    const actual = buildSellMsg(true, buyTokenLabel, sellTokenLabel, '', '')
+
+    expect(actual).toMatch(new RegExp(`Sell \`${sellTokenLabel}\` for \`${buyTokenLabel}\``))
+  })
+
+  test('limit order', () => {
+    const buyAmount = '1'
+    const sellAmount = '2'
+
+    const actual = buildSellMsg(false, buyTokenLabel, sellTokenLabel, buyAmount, sellAmount)
+
+    expect(actual).toMatch(
+      new RegExp(`Sell \\*${sellAmount}\\* \`${sellTokenLabel}\` for \\*${buyAmount}\\* \`${buyTokenLabel}\``),
+    )
+  })
+})
+
+describe('buildFillOrderMsg', () => {
+  const price = new BigNumber(1.1)
+  const baseUrl = 'http://dex.gnosis.io/'
+  const buyTokenParam = 'SCM'
+  const sellTokenParam = 'PMD'
+
+  test('unlimited order', () => {
+    const actual = buildFillOrderMsg(true, baseOrder, price, baseUrl, buyTokenParam, sellTokenParam)
+
+    expect(actual).toMatch(
+      new RegExp(`Fill the order here: ${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}\\?sell=11\\.022\\&buy=10`),
+    )
+  })
+
+  test('limited order', () => {
+    const actual = buildFillOrderMsg(false, baseOrder, price, baseUrl, buyTokenParam, sellTokenParam)
+
+    expect(actual).toMatch(
+      new RegExp(
+        `Fill the order here: ${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}\\?sell=0\\.000000000000009802\\&buy=0\\.00000000000000001`,
+      ),
+    )
+  })
+})

--- a/test/helpers/message.spec.ts
+++ b/test/helpers/message.spec.ts
@@ -8,6 +8,7 @@ import {
   buildNotYetActiveOrderMsg,
   buildSellMsg,
   buildFillOrderMsg,
+  calculateUnlimitedBuyTokenFillAmount,
 } from 'helpers'
 import { MAX_BATCH_ID } from '@gnosis.pm/dex-js'
 
@@ -115,6 +116,30 @@ describe('buildSellMsg', () => {
   })
 })
 
+describe('calculateUnlimitedBuyTokenFillAmount', () => {
+  const price = new BigNumber('1.001')
+
+  test('high precision token', () => {
+    const actual = calculateUnlimitedBuyTokenFillAmount(price, baseSellToken)
+
+    expect(actual).toBe('9.970029970029970029')
+  })
+
+  test('lower precision token', () => {
+    const actual = calculateUnlimitedBuyTokenFillAmount(price, { ...baseSellToken, decimals: 2 })
+
+    expect(actual).toBe('9.97')
+  })
+
+  test('price is an integer', () => {
+    const price = new BigNumber(2)
+
+    const actual = calculateUnlimitedBuyTokenFillAmount(price, baseSellToken)
+
+    expect(actual).toBe('4.99')
+  })
+})
+
 describe('buildFillOrderMsg', () => {
   const price = new BigNumber(1.1)
   const baseUrl = 'http://dex.gnosis.io/'
@@ -125,7 +150,9 @@ describe('buildFillOrderMsg', () => {
     const actual = buildFillOrderMsg(true, baseOrder, price, baseUrl, buyTokenParam, sellTokenParam)
 
     expect(actual).toMatch(
-      new RegExp(`Fill the order here: ${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}\\?sell=11\\.022\\&buy=10`),
+      new RegExp(
+        `Fill the order here: ${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}\\?sell=10\\&buy=9.0727272727272727`,
+      ),
     )
   })
 


### PR DESCRIPTION
## Fixing unlimited order notification.
Closes https://github.com/gnosis/dex-react/issues/436

- [x] Refactored further the way order message is built
- [x] Unit tests!!!
- [x] Managed to also test it on Rinkeby!
- [x] Buy prices for unlimited orders adjusted according to buy token precision

**Note**: Arbitrarily creating a `counter` order to unlimited orders by selling 10 units of the buy token and buying the proportional amount of the sell token. Still not sure where it makes sense to have a fill order link for unlimited orders at all.

### Liquidity details:
![screenshot_2020-01-27_16-09-48](https://user-images.githubusercontent.com/43217/73224895-d580c880-411f-11ea-87bc-e5955f85cad0.png)

### Notification on telegram:
![screenshot_2020-01-27_16-12-11](https://user-images.githubusercontent.com/43217/73224897-d74a8c00-411f-11ea-8e24-c77f2ded7f31.png)

