### PR TITLE
Fix issue formatting amounts

### DIFF
--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -27,7 +27,7 @@ function _getTokenFmt(amount: BigNumber, token: TokenDto) {
     tokenParam = token.address
   }
 
-  const amountFmt = formatAmount(new BN(amount.toString()), token.decimals) as string
+  const amountFmt = formatAmount(new BN(amount.toFixed()), token.decimals) as string
 
   return { tokenLabel, tokenParam, amountFmt }
 }
@@ -138,9 +138,9 @@ export function buildFillOrderMsg(
   } else {
     // Format the amounts
     // TODO: Allow to use BN, string or BigNumber or all three in the format. Review in dex-js
-    fillAmountBuy = formatAmountFull(new BN(priceDenominator.toString()), sellToken.decimals) as string
+    fillAmountBuy = formatAmountFull(new BN(priceDenominator.toFixed()), sellToken.decimals) as string
     fillAmountSell = formatAmountFull(
-      new BN(priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).toString()),
+      new BN(priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).toFixed()),
       buyToken.decimals,
     ) as string
   }


### PR DESCRIPTION
Closes #126 

BigNumber.toString write in scientific notation, so `1000000000000000000000` it's written to `1e21`

For this reason, converting a BigNumber into a BN cannot be done as `new BN(bigNumber.toString())` we need to do BN(bigNumber.toFixed())`

Note that `toFixed` can be used safely because it's an integer, actually what BN would expect (since it cannot handle decimals)