### PR TITLE
Show full amount for limited orders

### DIFF
--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -2,13 +2,7 @@ import BN from 'bn.js'
 import BigNumber from 'bignumber.js'
 import moment from 'moment-timezone'
 
-import {
-  FEE_DENOMINATOR,
-  formatAmountFull,
-  formatAmount,
-  isOrderUnlimited,
-  isNeverExpiresOrder,
-} from '@gnosis.pm/dex-js'
+import { FEE_DENOMINATOR, formatAmountFull, isOrderUnlimited, isNeverExpiresOrder } from '@gnosis.pm/dex-js'
 import { TokenDto, OrderDto } from 'services'
 
 // To fill an order, no solver will match the trades if there's not 2*FEE spread between the trades
@@ -27,7 +21,7 @@ function _getTokenFmt(amount: BigNumber, token: TokenDto) {
     tokenParam = token.address
   }
 
-  const amountFmt = formatAmount(new BN(amount.toFixed()), token.decimals) as string
+  const amountFmt = formatAmountFull(new BN(amount.toFixed()), token.decimals) as string
 
   return { tokenLabel, tokenParam, amountFmt }
 }


### PR DESCRIPTION
When testing https://github.com/gnosis/dex-telegram/pull/128, I realized that amounts smaller than 1 are displayed as 0 for all tokens.

This change always displays the full amount with all decimals.

Up to suggestion whether we should have this at all or display up to X decimals.

### Before
![screenshot_2020-02-10_10-33-33](https://user-images.githubusercontent.com/43217/74155171-d707c180-4bf2-11ea-82ad-fcf279f086b0.png)


### After

![screenshot_2020-02-10_10-33-42](https://user-images.githubusercontent.com/43217/74155184-dd963900-4bf2-11ea-8147-947d0b9760b6.png)

