### PR TITLE
160/improve price calculation

### DIFF
--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -2,7 +2,13 @@ import BN from 'bn.js'
 import BigNumber from 'bignumber.js'
 import moment from 'moment-timezone'
 
-import { FEE_DENOMINATOR, formatAmountFull, isOrderUnlimited, isNeverExpiresOrder, ZERO } from '@gnosis.pm/dex-js'
+import {
+  FEE_DENOMINATOR,
+  formatAmountFull,
+  isOrderUnlimited,
+  isNeverExpiresOrder,
+  DEFAULT_PRECISION,
+} from '@gnosis.pm/dex-js'
 import { TokenDto, OrderDto } from 'services'
 
 // To fill an order, no solver will match the trades if there's not 2*FEE spread between the trades
@@ -44,7 +50,7 @@ export function calculatePrice(
     price = priceNumerator.multipliedBy(precisionFactor).dividedBy(priceDenominator)
   }
 
-  return price.decimalPlaces(buyTokenDecimals, BigNumber.ROUND_FLOOR)
+  return price.decimalPlaces(DEFAULT_PRECISION, BigNumber.ROUND_FLOOR)
 }
 
 export function buildExpirationMsg(order: OrderDto): string {
@@ -129,38 +135,60 @@ export function buildFillOrderUrl(params: {
   price: BigNumber
 }): string {
   const { isUnlimited, order, baseUrl, buyTokenParam, sellTokenParam, price } = params
-  const { sellToken, buyToken, priceNumerator, priceDenominator } = order
+  const { sellToken, buyToken, priceNumerator } = order
+
+  // Calculate the maker theoretic price (theoretic because it needs adjustments because of precision errors)
+  const takerTheoreticalPrice = FILL_INVERSE_TRADE_PRICE_BASE.div(price)
+  console.log('takerTheoreticalPrice', takerTheoreticalPrice.toString(10))
+  console.log('takerTheoreticalPrice (fixed)', takerTheoreticalPrice.toFixed(DEFAULT_PRECISION))
 
   // Calculate the sell amount and price
-  let fillAmountSell: BN
-  let priceInverse: BigNumber
+  let takerSellAmount: string
+  let takerPrice: string
   if (isUnlimited) {
     // For unlimited orders, the user can enter any amount he wants
-    fillAmountSell = ZERO
+    takerSellAmount = '0'
 
     // Calculate the inverse price taking the fee into account
     //  (1 - 2*fee) / price
-    priceInverse = FILL_INVERSE_TRADE_PRICE_BASE.div(price).decimalPlaces(sellToken.decimals, BigNumber.ROUND_FLOOR)
+    takerPrice = takerTheoreticalPrice.decimalPlaces(DEFAULT_PRECISION, BigNumber.ROUND_FLOOR).toString(10)
   } else {
     // The taker needs to sell slightly more "buy tokens" than what the maker is expecting and at a slightly better price
-    fillAmountSell = new BN(priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).toFixed())
+    //    * The taker expects at least "priceNumerator buyTokens"
+    //    * We need take the fees into account (the taker needs to sell more tokens than the ones the maker receives)
+    const takerSellAmountWeis = priceNumerator.multipliedBy(FACTOR_TO_FILL_ORDER).decimalPlaces(0, BigNumber.ROUND_CEIL)
+    takerSellAmount = formatAmountFull(new BN(takerSellAmountWeis.toFixed()), buyToken.decimals, false)
+    console.log('takerSellAmount', takerSellAmount)
 
-    // Calculate the price inverse that makes the taker receive the expected tokens taking the fee into account
-    priceInverse = calculatePrice({
-      sellToken: buyToken,
+    // Calculate the taker buy tokens
+    const takerBuyAmountWeis = takerSellAmountWeis
+      .multipliedBy(takerTheoreticalPrice)
+      .dividedBy(10 ** (buyToken.decimals - sellToken.decimals))
+      .decimalPlaces(0, BigNumber.ROUND_FLOOR)
+
+    console.log(
+      'takerBuyTokens (decimals)',
+      takerSellAmountWeis
+        .multipliedBy(takerTheoreticalPrice)
+        .dividedBy(10 ** buyToken.decimals)
+        .toString(10),
+    )
+
+    console.log('takerBuyTokens', takerBuyAmountWeis.toString(10))
+
+    // Calculate the price
+    takerPrice = calculatePrice({
       buyToken: sellToken,
-      priceNumerator: priceDenominator,
-      priceDenominator: new BigNumber(fillAmountSell.toString(10)),
-    })
+      sellToken: buyToken,
+      priceNumerator: takerBuyAmountWeis,
+      priceDenominator: takerSellAmountWeis,
+    }).toString(10)
+    // takerSellAmountWeis.dividedBy(takerBuyTokensWeis).toFixed(DEFAULT_PRECISION, BigNumber.ROUND_FLOOR)
+    console.log('takerPrice', takerPrice)
   }
 
-  // Format the sell amount and price
-  const fillAmountSellFormatted = formatAmountFull(fillAmountSell, buyToken.decimals, false)
-  const priceInverseFormatted = priceInverse.toFixed(sellToken.decimals)
-
   // Calculate the fill price
-
-  return `${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}?sell=${fillAmountSellFormatted}&price=${priceInverseFormatted}`
+  return `${baseUrl}/trade/${buyTokenParam}-${sellTokenParam}?sell=${takerSellAmount}&price=${takerPrice}`
 }
 
 export function buildPriceMsg(params: {
@@ -170,9 +198,8 @@ export function buildPriceMsg(params: {
   buyTokenDecimals: number
   price: BigNumber
 }): string {
-  const { sellTokenDecimals, buyTokenDecimals, sellTokenLabel, buyTokenLabel, price } = params
-  const maxDecimals = Math.max(sellTokenDecimals, buyTokenDecimals)
-  const priceFormatted = price.toFixed(maxDecimals)
+  const { sellTokenLabel, buyTokenLabel, price } = params
+  const priceFormatted = price.toFixed(DEFAULT_PRECISION)
 
   return `1 \`${sellTokenLabel}\` = ${priceFormatted} \`${buyTokenLabel}\``
 }

--- a/test/helpers/message.spec.ts
+++ b/test/helpers/message.spec.ts
@@ -298,9 +298,9 @@ describe('newOrderMessage', () => {
     // Some intermediate steps to explain previous numbers:
     //    * Calculate the maker price:
     //        * Since he sells 1.23 token2 for 12.1 token1
-    //        => Price: 1.23 / 12.1 = 9.837398373983739837...
+    //        => Price: 12.1 / 1.23  = 9.8373983739837398374
     //    * Get taker theoretic price
-    //        * We need to apply to the price the 2 fees:   0.998 * 1 / 9.837398373983739837 = 0.101449586776859504...
+    //        * We need to apply to the price the 2 fees:   0.998 * 1 / 9.837398373983739837 = 0.1014495867768595041...
     //    * Calculate sell amount for taker:
     //        * The maker wants 12.1 token1 and the taker needs to include the two fees in the trade
     //        * Then the taker needs to sell:   12.1 / 0.998 = 12.124248497 token1
@@ -310,7 +310,7 @@ describe('newOrderMessage', () => {
     //        * Using the "theoretic taker price":  12.2 * 0.101449586776859504 = 1.2376849586776859488 token2
     //        * token2 have 2 decimal, we adjust precision flooring the value --->  1.23 token2
     //    * Calculate final price for taker:
-    //        * 1.23 / 12.2 = 0.100819672131147540
+    //        * 1.23 / 12.2 = 0.1008196721311475409
     expect(actual).toEqual(`Sell *1.23* \`${TOKEN_2}\` for *12.1* \`${BUY_TOKEN_SYMBOL}\`
 
   - *Price*:  1 \`${TOKEN_2}\` = 9.8373983739837398374 \`${BUY_TOKEN_SYMBOL}\`


### PR DESCRIPTION
Closes #160 

The current price has an issue with the decimals

Let me formulate it:
* We are selling `X` tokens for `Y` tokens at a price `P` => `P x X = Y`
* `precision(x)` is the precision of the token `x`
* `decimals(x)` is the number of decimals in `x`

We know:
* `decimals(x) < precision(x), for X and Y`

Ideally we want to find a P:
* That `decimals(P x X) <= precision(Y)`


Worst case is:
`decimals(P x X) = decimals(P) +  decimals(X)`

Therefore, there's not such `P` 😔
(since decimals(X) can be bigger than decimals(Y))

...unless we do this price calculation in two steps:

Let's see an example:
```
* decimals(A) = 2
* decimals(B) = 1
* amount A = 1.23
* P = 9.87654321

Calculate the receiving tokens at that price
P x A = 1.23 * 9.837398374 = 12.1481481483

Adjust receiving tokens
B = floor(12.1481481483, decimals(B)) = 12.1

Adjust P to satisfy the price formula:
1.23 * P = 12.1
P = 12.1 / 1.23 = 9.837398374
```

# Includes
* The solution described above:  Making sure we do the rounding rights for the taker: sellTokens are rounded up, buyTokens are rounded down, price is rounded down with high precision
* Increases precision of prices to 19 --> shouldn't depend on the token decimals as it was depending. Choosing 19 cause it's the maximum that you can get with BigNumber afaik and it looks like good enough for this use case
* Includes a complete example test, doing the math in the comments