### PR TITLE
Update dex js price stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ package-lock.json
 build
 coverage
 .vscode
+.yalc
+yalc.lock

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@gnosis.pm/dex-js": "0.1.12",
+    "@gnosis.pm/dex-js": "0.1.14-RC.2",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",

--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -125,8 +125,7 @@ export function buildFillOrderUrl(params: {
 
     // Calculate the inverse price taking the fee into account
     //  (1 - 2*fee) / price
-    const price = takerTheoreticalPrice.decimalPlaces(PRICE_PRECISION, BigNumber.ROUND_FLOOR)
-    takerPrice = formatPrice({ price, decimals: PRICE_PRECISION, zeroPadding: false })
+    takerPrice = formatPrice({ price: takerTheoreticalPrice, decimals: PRICE_PRECISION, zeroPadding: false })
   } else {
     // The taker needs to sell slightly more "buy tokens" than what the maker is expecting and at a slightly better price
     //    * The taker expects at least "priceNumerator buyTokens"

--- a/test/helpers/message.spec.ts
+++ b/test/helpers/message.spec.ts
@@ -4,7 +4,6 @@ import { TOKEN_1, TOKEN_2, USER_1 } from '../data'
 
 import { OrderDto, TokenDto } from 'services'
 import {
-  calculatePrice,
   buildExpirationMsg,
   buildUnknownTokenMsg,
   buildNotYetActiveOrderMsg,
@@ -39,76 +38,6 @@ const baseOrder: OrderDto = {
   validUntilBatchId: new BigNumber(1),
   event: new MockEvent(),
 }
-
-describe('calculatePrice', () => {
-  test('sell token with higher precision', () => {
-    // GIVEN: an order exchanging 20 token1 for 30 token2 (different precision)
-    const order = {
-      ...baseOrder,
-      sellToken: { ...baseSellToken, decimals: 18 },
-      buyToken: { ...baseBuyToken, decimals: 17 },
-      priceNumerator: new BigNumber(2000000000000000000),
-      priceDenominator: new BigNumber(30000000000000000000),
-    }
-
-    // WHEN: Calculating the price
-    const actual = calculatePrice(order)
-
-    // THEN Price is
-    expect(actual.toString(10)).toBe('0.6666666666666666666')
-  })
-
-  test('buy token with same or higher precision', () => {
-    // GIVEN: an order exchanging 20 token1 for 30 token2 (same precision)
-    const order = {
-      ...baseOrder,
-      sellToken: { ...baseSellToken, decimals: 18 },
-      buyToken: { ...baseBuyToken, decimals: 18 },
-      priceNumerator: new BigNumber(20000000000000000000),
-      priceDenominator: new BigNumber(30000000000000000000),
-    }
-
-    // WHEN: Calculating the price
-    const actual = calculatePrice(order)
-
-    // THEN Price is
-    expect(actual.toString(10)).toBe('0.6666666666666666666')
-  })
-
-  test('sell token with higher precision', () => {
-    // GIVEN: an order exchanging 20 token1 for 30 token2 (different precision)
-    const order = {
-      ...baseOrder,
-      sellToken: { ...baseSellToken, decimals: 18 },
-      buyToken: { ...baseBuyToken, decimals: 17 },
-      priceNumerator: new BigNumber(2000000000000000000),
-      priceDenominator: new BigNumber(30000000000000000000),
-    }
-
-    // WHEN: Calculating the price
-    const actual = calculatePrice(order)
-
-    // THEN Price is
-    expect(actual.toString(10)).toBe('0.6666666666666666666')
-  })
-
-  test('sell token with smaller precision', () => {
-    // GIVEN: an order exchanging 10 token1 for 11 token2 (different precision)
-    const order = {
-      ...baseOrder,
-      sellToken: { ...baseSellToken, decimals: 17 },
-      buyToken: { ...baseBuyToken, decimals: 18 },
-      priceNumerator: new BigNumber(20000000000000000000),
-      priceDenominator: new BigNumber(3000000000000000000),
-    }
-
-    // WHEN: Calculating the price
-    const actual = calculatePrice(order)
-
-    // THEN Price is
-    expect(actual.toString(10)).toBe('0.6666666666666666666')
-  })
-})
 
 describe('buildExpirationMsg', () => {
   test('With expiration', () => {
@@ -309,14 +238,14 @@ describe('newOrderMessage', () => {
     //        * Using the "theoretic taker price":  12.2 * 0.101449586776859504 = 1.2376849586776859488 token2
     //        * token2 have 2 decimal, we adjust precision flooring the value --->  1.23 token2
     //    * Calculate final price for taker:
-    //        * 1.23 / 12.2 = 0.1008196721311475409
+    //        * 1.23 / 12.2 = 0.1008196721311475409836065574
     expect(actual).toEqual(`Sell *1.23* \`${TOKEN_2}\` for *12.1* \`${BUY_TOKEN_SYMBOL}\`
 
   - *Price*:  1 \`${TOKEN_2}\` = 9.8373983739837398374 \`${BUY_TOKEN_SYMBOL}\`
-  - *Price*:  1 \`${BUY_TOKEN_SYMBOL}\` = 0.1016528925619834710 \`${TOKEN_2}\`
+  - *Price*:  1 \`${BUY_TOKEN_SYMBOL}\` = 0.1016528925619834711 \`${TOKEN_2}\`
   - *Expires*: \`Tomorrow at 12:00 AM GMT\`, \`in a day\`
 
-Fill the order here: http://dex.gnosis.io//trade/COOL-${TOKEN_2}?sell=12.2&price=0.1008196721311475409`)
+Fill the order here: http://dex.gnosis.io//trade/COOL-${TOKEN_2}?sell=12.2&price=0.100819672131147541`)
   })
 
   test('unlimited order', () => {
@@ -337,7 +266,7 @@ Fill the order here: http://dex.gnosis.io//trade/COOL-${TOKEN_2}?sell=12.2&price
     expect(actual).toEqual(`Sell *3* \`${TOKEN_2}\` for *10* \`${BUY_TOKEN_SYMBOL}\`
 
   - *Price*:  1 \`${TOKEN_2}\` = 3.3333333333333333333 \`${BUY_TOKEN_SYMBOL}\`
-  - *Price*:  1 \`${BUY_TOKEN_SYMBOL}\` = 0.3000000000000000000 \`${TOKEN_2}\`
+  - *Price*:  1 \`${BUY_TOKEN_SYMBOL}\` = 0.3 \`${TOKEN_2}\`
   - *Expires*: \`Tomorrow at 12:00 AM GMT\`, \`in a day\`
 
 Fill the order here: http://dex.gnosis.io//trade/COOL-${TOKEN_2}?sell=10.02&price=0.2994`)
@@ -365,7 +294,7 @@ describe('newOrderMessage', () => {
     expect(actual).toEqual(`Sell *3* \`${TOKEN_2}\` for *10* \`${BUY_TOKEN_SYMBOL}\`
 
   - *Price*:  1 \`${TOKEN_2}\` = 3.3333333333333333333 \`${BUY_TOKEN_SYMBOL}\`
-  - *Price*:  1 \`${BUY_TOKEN_SYMBOL}\` = 0.3000000000000000000 \`${TOKEN_2}\`
+  - *Price*:  1 \`${BUY_TOKEN_SYMBOL}\` = 0.3 \`${TOKEN_2}\`
   - *Expires*: \`Tomorrow at 12:00 AM GMT\`, \`in a day\`
 
 Fill the order here: http://dex.gnosis.io//trade/COOL-${TOKEN_2}?sell=10.02&price=0.2994`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.1.12":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.12.tgz#a8ab65966c7f20c98bc6bff12d16c8937bd2ed4b"
-  integrity sha512-A1WFUntxsSL47+UWanu1/gwm9Y1KB5ghSs17jXgFqviDOgg+yOgQP+GK2GFhSNkMTXsa1zqqoSEmKKT9fULLyw==
+"@gnosis.pm/dex-js@0.1.14-RC.2":
+  version "0.1.14-RC.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.14-RC.2.tgz#fd9e6fd8e4aba5ff74f30e08aafe194d83ffba3a"
+  integrity sha512-YJAOt9m19vKrmqUBiAK8PVCDtbbi0Dg0nQD3L1psyk36aAx342IAgGtn49HnE+V96qEotokfWa7X6vx5lgwVmQ==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Applying latest `dex-js` updates https://github.com/gnosis/dex-js/pull/118

Using `calculatePrice`, `invertPrice` and `formatPrice` from common utils.

Functional change is that now all prices will NOT be zero padded. Instead of showing `0.30000000000000000000000`, we'll show `0.3`.
And we do rounding instead of truncating on the price.