### PR TITLE
Bumping dex-js to fix formatPrice

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@gnosis.pm/dex-js": "0.1.15-RC.0",
+    "@gnosis.pm/dex-js": "0.1.16",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.1.15-RC.0":
-  version "0.1.15-RC.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.15-RC.0.tgz#254eec10c8135c9f97fa0f3156779021f4345e8e"
-  integrity sha512-yTIcGr5koHmYn5LvMQLOYfJxQBb3X/ngZe6BX565QjT5yivwzhRtIGDbPSOR6qbGQKTGm/MEs6DagS6EORMduw==
+"@gnosis.pm/dex-js@0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.16.tgz#1308228f8ed90c90453920bb3cdb6a25f8ceb657"
+  integrity sha512-nlc1cjFD1nPiUz/u/x1++W1EzbAoo7IRiu1YMf+WU5f7I6X5jaqTp0pDBbQrw7u8k3qes8m2RsQLQk3oSfGnew==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Fixing #174 

Prices with 0s after decimal separator are properly displayed

0.007... no longer shows as 0.7...

![screenshot_2020-03-30_09-14-13](https://user-images.githubusercontent.com/43217/77935841-da204500-7266-11ea-900c-4b7f8658756e.png)


