### PR TITLE
Release/0.8.2

### DIFF
--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -161,6 +161,7 @@ export class DfusionRepoImpl implements DfusionService {
           validFrom: validFromBatchIdString,
           validUntil: validUntilBatchIdString,
         } = event.returnValues
+
         const priceNumerator = new BigNumber(priceNumeratorString)
         const priceDenominator = new BigNumber(priceDenominatorString)
         const validFromBatchId = new BigNumber(validFromBatchIdString)


### PR DESCRIPTION
It seems coveralls breaks with
```sh
Bad response: 422 {"message":"service_job_id (680006426) must be unique for Travis Jobs not supplying a Coveralls Repo Token","error":true}
```
when it receives the same data for same branch on travis build restart. I'm not entirely sure.
So if previous travis build posted to coveralls but ultimately failed, an new restarted build can't post to coveralls again. Or so I think is what happens.
But as a result we can't have a build succeed.
So have to recreate a release.
Another way could be adding `Coveralls Repo Token`