### PR TITLE
Release/v0.9.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ STABLE_COIN_CONTRACT_ADDRESS=0x67B5656d60a809915323Bf2C40A8bEF15A152e3e
 #   https://github.com/gnosis/dex-react
 WEB_BASE_URL=https://dex-react
 
+# TCR - list of whitelisted tokens
+#  contract address, required
+# Rinkeby:
+#TCR_CONTRACT_ADDRESS=0xBb840456546496E7640DC09ba9fE06E67C157E1b
+# Mainnet:
+#TCR_CONTRACT_ADDRESS=0x1854dae560abb0f399d8badca456663ca5c309d0
+#  optional list id, defaults to 0
+#TCR_LIST_ID=1
+
 
 #################################
 #   Other config

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@gnosis.pm/dex-js": "0.2.3-RC.2",
+    "@gnosis.pm/dex-js": "0.3.0-RC.2",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
+    "node-cache": "^5.1.0",
     "node-telegram-bot-api": "^0.40.0",
     "rxjs": "7.0.0-beta.0",
     "web3": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@gnosis.pm/dex-js": "0.3.0-RC.2",
+    "@gnosis.pm/dex-js": "0.3.0",
     "bignumber.js": "^9.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,6 +12,8 @@ const WEB_BASE_URL = process.env.WEB_BASE_URL
 assert(WEB_BASE_URL, 'WEB_BASE_URL is required')
 const port = parseInt(process.env.API_PORT || '3000')
 
+assert(process.env.TCR_CONTRACT_ADDRESS, 'TCR_CONTRACT_ADDRESS env var is required')
+
 moment.tz.setDefault('Etc/GMT')
 
 logUnhandledErrors()
@@ -85,6 +87,8 @@ async function _aboutCommand(msg: Message) {
     dexJsVersion,
     contractsVersion,
     batchExchangeAddress,
+    tcrContractAddress,
+    tcrListId,
   } = await dfusionService.getAbout()
 
   return bot.sendMessage(
@@ -103,6 +107,8 @@ Some interesting facts are:
 - Bot version: ${version}
 - Contract version: ${contractsVersion}
 - dex-js version: ${dexJsVersion}
+- TCR Contract Address: ${tcrContractAddress}
+- TCR list id: ${tcrListId}
 
 Also, here are some links you may find useful:
 - https://github.com/gnosis/dex-contracts: Gnosis Protocol Smart Contracts

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,3 @@
+export const TCR_CONTRACT_ADDRESS = process.env.TCR_CONTRACT_ADDRESS
+export const TCR_LIST_ID = Number(process.env.TCR_LIST_ID) || 0
+export const TCR_CACHE_TIME = 5 * 60 * 1000

--- a/src/helpers/contracts.ts
+++ b/src/helpers/contracts.ts
@@ -1,5 +1,7 @@
-import { createBatchExchangeContract, createErc20Contract } from '@gnosis.pm/dex-js'
+import { createBatchExchangeContract, createErc20Contract, createTcrContract } from '@gnosis.pm/dex-js'
 import { web3 } from './web3'
+import { TCR_CONTRACT_ADDRESS } from 'config'
 
 export const batchExchangeContract = createBatchExchangeContract(web3)
 export const erc20Contract = createErc20Contract(web3)
+export const tcrContract = createTcrContract(web3, TCR_CONTRACT_ADDRESS)

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -161,6 +161,7 @@ export class DfusionRepoImpl implements DfusionService {
           validFrom: validFromBatchIdString,
           validUntil: validUntilBatchIdString,
         } = event.returnValues
+
         const priceNumerator = new BigNumber(priceNumeratorString)
         const priceDenominator = new BigNumber(priceDenominatorString)
         const validFromBatchId = new BigNumber(validFromBatchIdString)

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -1,11 +1,13 @@
 import Web3 from 'web3'
 
 import { Logger, ContractEventLog, tokenList, Erc20Contract, BatchExchangeContract } from '@gnosis.pm/dex-js'
+import { TcrContract } from '@gnosis.pm/dex-js/build-esm/contracts/TcrContract'
 
 import packageJson from '../../package.json'
 import { BigNumber } from 'bignumber.js'
 import { version as dexJsVersion } from '@gnosis.pm/dex-js/package.json'
 import { version as contractsVersion } from '@gnosis.pm/dex-contracts/package.json'
+import { TCR_LIST_ID, TCR_CACHE_TIME } from 'config'
 
 const PEER_COUNT_WARN_THRESHOLD = 3 // Warning if the node has less than X peers
 const BLOCK_TIME_ERR_THRESHOLD_MINUTES = 2 // Error if there's no a new block in X min
@@ -15,6 +17,7 @@ const log = new Logger('service:dfusion')
 export interface Params {
   batchExchangeContract: BatchExchangeContract
   erc20Contract: Erc20Contract
+  tcrContract: TcrContract
   web3: Web3
 }
 
@@ -65,6 +68,8 @@ export interface AboutDto {
   contractsVersion: string
   dexJsVersion: string
   batchExchangeAddress: string
+  tcrContractAddress: string
+  tcrListId: number
 }
 
 export interface OrderDto {
@@ -78,22 +83,26 @@ export interface OrderDto {
   priceNumerator: BigNumber
   priceDenominator: BigNumber
   event: ContractEventLog<OrderPlacement>
+  networkId: number
 }
 
 export class DfusionRepoImpl implements DfusionService {
   private _web3: Web3
   private _contract: BatchExchangeContract
   private _erc20Contract: Erc20Contract
+  private _tcrContract: TcrContract
   private _networkId: number
   private _batchTime: BigNumber
   private _tokenCache: { [tokenAddress: string]: TokenDto } = {}
+  private _tcrCache: { lastUpdate: number; addresses: Set<string> } = { lastUpdate: 0, addresses: new Set<string>() }
 
   constructor(params: Params) {
-    const { web3, batchExchangeContract, erc20Contract } = params
+    const { web3, batchExchangeContract, erc20Contract, tcrContract } = params
     log.debug('Setup dfusionRepo with contract address %s', batchExchangeContract.options.address)
 
     this._contract = batchExchangeContract
     this._erc20Contract = erc20Contract
+    this._tcrContract = tcrContract
     this._web3 = web3
   }
 
@@ -198,6 +207,7 @@ export class DfusionRepoImpl implements DfusionService {
           validFrom: validFrom as Date,
           validUntil: validUntil as Date,
           event,
+          networkId: await this._getNetworkId(),
         })
       })
       .on('changed', data => {
@@ -223,6 +233,8 @@ export class DfusionRepoImpl implements DfusionService {
       dexJsVersion,
       version: packageJson.version,
       batchExchangeAddress: this._contract.options.address,
+      tcrContractAddress: this._tcrContract.options.address,
+      tcrListId: TCR_LIST_ID,
     }
   }
 
@@ -246,13 +258,16 @@ export class DfusionRepoImpl implements DfusionService {
     let token = this._tokenCache[tokenAddress]
 
     if (!token) {
-      const networkId = await this._getNetworkId()
-
       const tokenContract = this._erc20Contract.clone()
       tokenContract.options.address = tokenAddress
 
-      // Get basic data from the contract
-      const { symbol, decimals, name } = await _getDataFromErc20(tokenContract)
+      const [networkId, { symbol, decimals, name }, tcr] = await Promise.all([
+        this._getNetworkId(),
+        // Get basic data from the contract
+        _getDataFromErc20(tokenContract),
+        // Get addresses from TCR
+        this._getTcr(),
+      ])
 
       const tokenJson = tokenList.find(token => token.addressByNetwork[networkId] === tokenAddress)
       token = {
@@ -261,7 +276,7 @@ export class DfusionRepoImpl implements DfusionService {
         ...tokenJson,
         decimals: decimals as number,
         address: tokenAddress,
-        known: !!tokenJson,
+        known: !!tokenJson || (tcr.size > 0 && tcr.has(tokenAddress)),
       }
 
       // Cache token if it's found, or null if is not
@@ -288,6 +303,24 @@ export class DfusionRepoImpl implements DfusionService {
         .multipliedBy(new BigNumber(1000))
         .toNumber(),
     )
+  }
+
+  private async _getTcr(): Promise<Set<string>> {
+    const { lastUpdate, addresses } = this._tcrCache
+
+    // Primitive caching - update once every 5min
+    if (!lastUpdate || lastUpdate < Date.now() - TCR_CACHE_TIME) {
+      const tcrList = await this._tcrContract.methods
+        .getTokens(TCR_LIST_ID)
+        .call()
+        .catch(() => [])
+
+      tcrList.forEach(address => addresses.add(address))
+
+      this._tcrCache.lastUpdate = Date.now()
+    }
+
+    return addresses
   }
 }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,4 @@
-import { batchExchangeContract, erc20Contract } from 'helpers/contracts'
+import { batchExchangeContract, erc20Contract, tcrContract } from 'helpers/contracts'
 import { web3 } from 'helpers/web3'
 
 import DfusionServiceImpl, { DfusionService } from 'services/DfusionService'
@@ -7,6 +7,7 @@ function createDfusionService(): DfusionService {
   return new DfusionServiceImpl({
     batchExchangeContract,
     erc20Contract,
+    tcrContract,
     web3,
   })
 }

--- a/test/helpers/message.spec.ts
+++ b/test/helpers/message.spec.ts
@@ -39,6 +39,7 @@ const baseOrder: OrderDto = {
   validFromBatchId: new BigNumber(0),
   validUntilBatchId: new BigNumber(1),
   event: new MockEvent(),
+  networkId: 1,
 }
 
 describe('buildExpirationMsg', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.2.3-RC.2":
-  version "0.2.3-RC.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.3-RC.2.tgz#8fbbf81330f99e1b33bfd9f229b3e63a776785e1"
-  integrity sha512-WbJh3utuS3GpNj0aHUmjWa1f4jIaCmCh5cJ+3UVbp4vqoXMhHlypD0kS1YdMMEmit94habDcfTcMBTMPWyt9Zw==
+"@gnosis.pm/dex-js@0.3.0-RC.2":
+  version "0.3.0-RC.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.3.0-RC.2.tgz#36b1d8520d54be27cf6519c4bd7bcf6048993f5d"
+  integrity sha512-nnoW4E/v4ddieHE57OM2ZsYx0M8qKOxrT/QTJ3k42U6UC/DzuVuo+gjAJOW5EccJn3LOrcjv/iGknsRkFSkCCg==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,6 +1531,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4623,6 +4628,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-cache@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
+  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
+  dependencies:
+    clone "2.x"
 
 node-int64@^0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.3.0-RC.2":
-  version "0.3.0-RC.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.3.0-RC.2.tgz#36b1d8520d54be27cf6519c4bd7bcf6048993f5d"
-  integrity sha512-nnoW4E/v4ddieHE57OM2ZsYx0M8qKOxrT/QTJ3k42U6UC/DzuVuo+gjAJOW5EccJn3LOrcjv/iGknsRkFSkCCg==
+"@gnosis.pm/dex-js@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.3.0.tgz#7e52af18c73f190418af9b4a5f60b5d44578a09e"
+  integrity sha512-6kClU2SvOH77Df27k3YVg6Gqro5k2MJQWD0iyaNLlC/nf/igJeLTd3ICEEFukZpnPHDewNkd9xXiX/3amM41hg==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
# Release `v0.9.0`

» git log --oneline
260541b (HEAD -> release/v0.9.0) Bumping dex-js to latest non-rc version
b6129dd (origin/develop, origin/HEAD) 199/caching lib again (#202)
cdd90ad shorter default delay between retries (#201)
e761dd4 180/tcr (#198)
a294205 Merge branch 'master' into develop

Mainly TCR and telegram retry bug fix.
