### PR TITLE
Optional local override for token details

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,25 @@
 export const TCR_CONTRACT_ADDRESS = process.env.TCR_CONTRACT_ADDRESS
 export const TCR_LIST_ID = Number(process.env.TCR_LIST_ID) || 0
 export const TCR_CACHE_TIME = 5 * 60 * 1000
+export const TOKEN_OVERRIDES = {
+  1: {
+    // Deprecated sUSD proxy contract
+    '0x57ab1e02fee23774580c119740129eac7081e9d3': {
+      forceAddressDisplay: true,
+    },
+    // Deprecated SNX proxy contract
+    '0xc011a72400e58ecd99ee497cf89e3775d4bd732f': {
+      forceAddressDisplay: true,
+    },
+  },
+  4: {
+    // Just for testing, this is not really deprecated
+    '0x1b642a124cdfa1e5835276a6ddaa6cfc4b35d52c': {
+      // Override any token detail
+      // name: 'Synthetics sUSD (deprecated) (this is rinkeby, so not really)',
+      // symbol: 'sUSD-old',
+      // decimals: 18,
+      forceAddressDisplay: true, // name and symbol are ignored when `forceAddressDisplay` is set
+    },
+  },
+}

--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -26,7 +26,10 @@ const FILL_INVERSE_TRADE_PRICE_BASE = new BigNumber(1 - 2 / FEE_DENOMINATOR)
 function _getTokenFmt(amount: BigNumber, token: TokenDto) {
   let tokenLabel, tokenParam
 
-  if (token.known) {
+  if (token.forceAddressDisplay) {
+    tokenParam = token.address
+    tokenLabel = token.address
+  } else if (token.known) {
     tokenLabel = token.symbol || token.name || token.address
     tokenParam = encodeTokenSymbol(token)
   } else {

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -70,6 +70,10 @@ export interface TokenDto {
   forceAddressDisplay?: boolean
 }
 
+interface LocalOverride extends Pick<TokenDto, 'name' | 'symbol' | 'forceAddressDisplay'> {
+  decimals?: number
+}
+
 export interface AboutDto {
   blockNumber: number
   networkId: number
@@ -313,20 +317,22 @@ export class DfusionRepoImpl implements DfusionService {
         this._getTcr(),
       ])
 
-      const localOverride = TOKEN_OVERRIDES[networkId][tokenAddress.toLowerCase()]
+      let localOverride: LocalOverride = TOKEN_OVERRIDES[networkId][tokenAddress.toLowerCase()]
       if (localOverride) {
         log.info(`Local override found for token address ${tokenAddress} on network ${networkId}:`, localOverride)
+      } else {
+        localOverride = {}
       }
 
       const tokenJson = tokenList.find(token => token.addressByNetwork[networkId] === tokenAddress)
       token = {
+        symbol,
+        name,
+        decimals: decimals as number,
         ...tokenJson,
-        symbol: localOverride?.symbol || symbol,
-        name: localOverride?.name || name,
-        decimals: localOverride?.decimals || (decimals as number),
+        ...localOverride,
         address: tokenAddress,
         known: !!tokenJson || (tcr.size > 0 && tcr.has(tokenAddress)),
-        forceAddressDisplay: localOverride?.forceAddressDisplay,
       }
 
       // Cache token if it's found, or null if is not

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -15,7 +15,7 @@ import packageJson from '../../package.json'
 import { BigNumber } from 'bignumber.js'
 import { version as dexJsVersion } from '@gnosis.pm/dex-js/package.json'
 import { version as contractsVersion } from '@gnosis.pm/dex-contracts/package.json'
-import { TCR_LIST_ID, TCR_CACHE_TIME } from 'config'
+import { TCR_LIST_ID, TCR_CACHE_TIME, TOKEN_OVERRIDES } from 'config'
 
 const PEER_COUNT_WARN_THRESHOLD = 3 // Warning if the node has less than X peers
 const BLOCK_TIME_ERR_THRESHOLD_MINUTES = 2 // Error if there's no a new block in X min
@@ -67,6 +67,7 @@ export interface TokenDto {
   decimals: number
   address: string
   known: boolean
+  forceAddressDisplay?: boolean
 }
 
 export interface AboutDto {
@@ -312,14 +313,20 @@ export class DfusionRepoImpl implements DfusionService {
         this._getTcr(),
       ])
 
+      const localOverride = TOKEN_OVERRIDES[networkId][tokenAddress.toLowerCase()]
+      if (localOverride) {
+        log.info(`Local override found for token address ${tokenAddress} on network ${networkId}:`, localOverride)
+      }
+
       const tokenJson = tokenList.find(token => token.addressByNetwork[networkId] === tokenAddress)
       token = {
-        symbol,
-        name,
         ...tokenJson,
-        decimals: decimals as number,
+        symbol: localOverride?.symbol || symbol,
+        name: localOverride?.name || name,
+        decimals: localOverride?.decimals || (decimals as number),
         address: tokenAddress,
         known: !!tokenJson || (tcr.size > 0 && tcr.has(tokenAddress)),
+        forceAddressDisplay: localOverride?.forceAddressDisplay,
       }
 
       // Cache token if it's found, or null if is not


### PR DESCRIPTION
Making it possible to override token details, such as `symbol`, `name` and `decimals`.

Also allowing to force display of token address instead of `symbol`.

Added old `SNX` and `sUSD` mainnet contract addresses to have their addresses displayed instead.

Before and after:
![screenshot_2020-06-30_11-15-09](https://user-images.githubusercontent.com/43217/86161936-e1075f80-bac2-11ea-9ee9-a773eb09a119.png)
