### PR TITLE
Retry on eth_subscribe not supported

### DIFF
--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -32,6 +32,12 @@ declare module 'web3-core' {
 
 }
 
+declare module 'web3-core-subscriptions' {
+  interface Subscription<T> {
+    resubscribe(): void
+  }
+}
+
 const PEER_COUNT_WARN_THRESHOLD = 3 // Warning if the node has less than X peers
 const BLOCK_TIME_ERR_THRESHOLD_MINUTES = 2 // Error if there's no a new block in X min
 

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -168,7 +168,6 @@ export class DfusionRepoImpl implements DfusionService {
     }
 
     this._cache = new NodeCache({ useClones: false })
-    console.log('subs:0', (web3 as any)._requestManager.subscriptions.size)
 
     const subNewHeads = () => {
       const sub = web3.eth.subscribe('newBlockHeaders', function(error, result) {
@@ -190,10 +189,6 @@ export class DfusionRepoImpl implements DfusionService {
     }
 
     subNewHeads()
-    console.log('subs:1', (web3 as any)._requestManager.subscriptions.size)
-    setInterval(() => {
-      console.log('subs:INTERVAL', (web3 as any)._requestManager.subscriptions.size)
-    }, 5000)
   }
 
   public async isHealthy(): Promise<boolean> {
@@ -284,13 +279,11 @@ export class DfusionRepoImpl implements DfusionService {
     }
   }
 
-  private reconnectAndResubscribe<T>(provider: WebsocketProvider, { subscription, name }: {subscription: Subscription<T>, name?: string}) {
+  private reconnectAndResubscribe<T>(provider: WebsocketProvider, { subscription, name }: { subscription: Subscription<T>, name?: string }) {
     // retry subscription when connection is established
     // expect several `eth_subscribe not supported` errors in a row
     provider.once('connect', () => {
-      console.log('CONNECTED_CONNECTED')
       log.info('Retrying subscription to %s', name)
-      // eslint-disable-next-line dot-notation
       subscription.resubscribe()
     })
 

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -156,6 +156,32 @@ export class DfusionRepoImpl implements DfusionService {
     }
 
     this._cache = new NodeCache({ useClones: false })
+    console.log('subs:0', (web3 as any)._requestManager.subscriptions.size)
+
+    const subNewHeads = () => {
+      const sub = web3.eth.subscribe('newBlockHeaders', function(error, result) {
+        if (!error) {
+          console.log('newBlockHeaders::CallbackResult', result)
+  }
+        // console.error('newBlockHeaders::CallbackError', error)
+      })
+        .on('connected', function(subscriptionId) {
+          console.log('newBlockHeaders::Connected', subscriptionId)
+        })
+        .on('data', function(blockHeader) {
+          console.log('newBlockHeaders::Data', blockHeader)
+        })
+        .on('error', error => {
+          console.error('newBlockHeaders::Error', error)
+          this.handleSubscriptionError(error, { subscription: sub, name: 'newBlockHeaders' })
+        })
+    }
+
+    subNewHeads()
+    console.log('subs:1', (web3 as any)._requestManager.subscriptions.size)
+    setInterval(() => {
+      console.log('subs:INTERVAL', (web3 as any)._requestManager.subscriptions.size)
+    }, 5000)
   }
 
   public async isHealthy(): Promise<boolean> {

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -124,7 +124,7 @@ export interface OrderDto {
 const TIME_TO_FLUSH_RESPONSES = 1000 // ms
 // time to wait before hard disconnecting an open connection
 
-// codes 4000-4999 are available for us by applications
+// codes 4000-4999 are available for use by applications
 // let's use 4000 for eth_subscribe reason
 const ETH_SUBSCRIBE_NOT_SUPPORTED = {
   code: 4000,

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -364,6 +364,7 @@ export class DfusionRepoImpl implements DfusionService {
       })
       .on('error', (error: Error) => {
         params.onError(error)
+        this.handleSubscriptionError(error, { subscription, name: subscriptionName })
       })
   }
 

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -175,27 +175,6 @@ export class DfusionRepoImpl implements DfusionService {
     }
 
     this._cache = new NodeCache({ useClones: false })
-
-    const subNewHeads = () => {
-      const sub = web3.eth.subscribe('newBlockHeaders', function(error, result) {
-        if (!error) {
-          console.log('newBlockHeaders::CallbackResult', result)
-        }
-        // console.error('newBlockHeaders::CallbackError', error)
-      })
-        .on('connected', function(subscriptionId) {
-          console.log('newBlockHeaders::Connected', subscriptionId)
-        })
-        .on('data', function(blockHeader) {
-          console.log('newBlockHeaders::Data', blockHeader)
-        })
-        .on('error', error => {
-          console.error('newBlockHeaders::Error', error)
-          this.handleSubscriptionError(error, { subscription: sub, name: 'newBlockHeaders' })
-        })
-    }
-
-    subNewHeads()
   }
 
   public async isHealthy(): Promise<boolean> {

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -114,6 +114,9 @@ export interface OrderDto {
   networkId: number
 }
 
+const TIME_TO_FLUSH_RESPONSES = 1000 // ms
+// time to wait before hard disconnecting an open connection
+
 export class DfusionRepoImpl implements DfusionService {
   private _web3: Web3
   private _contract: BatchExchangeContract

--- a/src/services/DfusionService.ts
+++ b/src/services/DfusionService.ts
@@ -125,6 +125,8 @@ export class DfusionRepoImpl implements DfusionService {
   private _batchTime: BigNumber
   private _cache: NodeCache
 
+  private _reconnecting = false
+
   constructor(params: Params) {
     const { web3, batchExchangeContract, erc20Contract, tcrContract, tokenIdsFilter } = params
     log.debug('Setup dfusionRepo with contract address %s', batchExchangeContract.options.address)


### PR DESCRIPTION
At times when connecting to `wss://rpc.xdaichain.com/wss` and trying to establish a subscription we get `Method eth_subscribe is not supported`
This can only be resolved by trying a new connection, sometimes several times.

To reproduce easily try several times
```sh
npx wscat -c wss://rpc.xdaichain.com/wss -x '{"method":"eth_subscribe","params":["newHeads"],"id":1,"jsonrpc":"2.0"}'
```

Right now the xDAI bot uses an alternative endpoint, `wss://xdai.poanetwork.dev/wss`, which doesn't have this problem. But that node often has `peerCount` as low as 2, which may lead to slow block discovery and therefore delayed OrderPlacement events and as a side effect -- `Health check error. No block has been mined in the last 2 minutes`

```sh
#compare
curl -X POST --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' https://rpc.xdaichain.com/
curl -X POST --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' --header 'Content-Type: application/json' https://xdai.poanetwork.dev/
```

This PR introduces reconnect+resubscribe logic when encountering `Method eth_subscribe is not supported` error.
I also propose switching back to `wss://rpc.xdaichain.com/wss` endpoint for better peerCount